### PR TITLE
schemas: Drop trayIconsReloaded in favour of appindicator

### DIFF
--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -7,7 +7,6 @@ gnome_schemas = [
     'org.gnome.nautilus.icon-view.gschema.override',
     'org.gnome.nautilus.list-view.gschema.override',
     'org.gnome.nautilus.preferences.gschema.override',
-    'org.gnome.shell.extensions.trayIconsReloaded.gschema.override',
     'org.gnome.shell.extensions.user-theme.gschema.override',
     'org.gnome.shell.gschema.override',
     'org.gtk.settings.file-chooser.gschema.override',

--- a/schemas/org.gnome.shell.extensions.trayIconsReloaded.gschema.override
+++ b/schemas/org.gnome.shell.extensions.trayIconsReloaded.gschema.override
@@ -1,5 +1,0 @@
-[org.gnome.shell.extensions.trayIconsReloaded]
-icon-saturation=0
-icon-size=16
-icon-spacing=16
-icons-limit=8

--- a/schemas/org.gnome.shell.gschema.override
+++ b/schemas/org.gnome.shell.gschema.override
@@ -1,3 +1,3 @@
 [org.gnome.shell]
-enabled-extensions=['impatience@gfxmonk.net', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'trayIconsReloaded@selfmade.pl', 'drive-menu@gnome-shell-extensions.gcampax.github.com']
+enabled-extensions=['impatience@gfxmonk.net', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'appindicatorsupport@rgcjonas.gmail.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com']
 favorite-apps=['solus-sc.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop','org.gnome.Rhythmbox3.desktop']


### PR DESCRIPTION
https://github.com/ubuntu/gnome-shell-extension-appindicator

This supports appindicator icons as well as provides wayland support unlike trayIconsReloaded.

Additionally, being used by Ubuntu it should be updated in time for new gnome-shell versions (It already has support for the big breakage in gnome 45 for example).

Resolves #3.