### PR TITLE
schemas: Enable speedinator extension by default

### DIFF
--- a/schemas/org.gnome.shell.gschema.override
+++ b/schemas/org.gnome.shell.gschema.override
@@ -1,3 +1,3 @@
 [org.gnome.shell]
-enabled-extensions=['user-theme@gnome-shell-extensions.gcampax.github.com', 'appindicatorsupport@rgcjonas.gmail.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com']
+enabled-extensions=['user-theme@gnome-shell-extensions.gcampax.github.com', 'appindicatorsupport@rgcjonas.gmail.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com', 'speedinator@liam.moe']
 favorite-apps=['solus-sc.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop','org.gnome.Rhythmbox3.desktop']


### PR DESCRIPTION
To replace impatience for GNOME 45+