### PR TITLE
schemas: Enable Solus logo in org.gnome.login-screen

### DIFF
--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -5,6 +5,7 @@ gnome_schemas = [
     'org.gnome.desktop.wm.keybindings.gschema.override',
     'org.gnome.desktop.wm.preferences.gschema.override',
     'org.gnome.gedit.preferences.editor.override',
+    'org.gnome.login-screen.override',
     'org.gnome.nautilus.icon-view.gschema.override',
     'org.gnome.nautilus.list-view.gschema.override',
     'org.gnome.nautilus.preferences.gschema.override',

--- a/schemas/org.gnome.login-screen.override
+++ b/schemas/org.gnome.login-screen.override
@@ -1,0 +1,2 @@
+[org.gnome.login-screen]
+logo='/usr/share/icons/hicolor/scalable/places/distributor-logo-solus.svg'


### PR DESCRIPTION
Shows the Solus login in the bottom center of the login screen. Resolves #12.