### PR TITLE
schemas: Drop rhythmbox from favourite applications

### DIFF
--- a/schemas/org.gnome.shell.gschema.override
+++ b/schemas/org.gnome.shell.gschema.override
@@ -1,3 +1,3 @@
 [org.gnome.shell]
 enabled-extensions=['user-theme@gnome-shell-extensions.gcampax.github.com', 'appindicatorsupport@rgcjonas.gmail.com', 'drive-menu@gnome-shell-extensions.gcampax.github.com', 'speedinator@liam.moe']
-favorite-apps=['solus-sc.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop','org.gnome.Rhythmbox3.desktop']
+favorite-apps=['solus-sc.desktop','org.gnome.Nautilus.desktop','firefox.desktop','io.github.celluloid_player.Celluloid.desktop']


### PR DESCRIPTION
rhythmbox will no longer be installed OOTB for new ISOs post GNOME 46.