### PR TITLE
env: Enable qadwaitadecorations

### DIFF
--- a/env/60-qadwaitadecorations.sh
+++ b/env/60-qadwaitadecorations.sh
@@ -1,0 +1,5 @@
+# Begin /usr/share/defaults/etc/profile.d/60-qadwaitadecorations.sh
+
+export QT_WAYLAND_DECORATION=adwaita
+
+# End /usr/share/defaults/etc/profile.d/60-qadwaitadecorations.sh

--- a/env/meson.build
+++ b/env/meson.build
@@ -2,3 +2,8 @@ install_data(
     '60-gnome-gl.sh',
     install_dir: path_envdir,
 )
+
+install_data(
+    '60-qadwaitadecorations.sh',
+    install_dir: path_envdir,
+)


### PR DESCRIPTION
When qtstyleplugins is installed then this env variable is needed to enable qadwaitadeocrations. As we previously installed qtstyleplugins as part of the desktop branding and can't forcibly remove it from user's systems, we need to set the env.