### PR TITLE
schemas: Default to light theme

### DIFF
--- a/schemas/org.gnome.desktop.interface.gschema.override
+++ b/schemas/org.gnome.desktop.interface.gschema.override
@@ -1,11 +1,10 @@
 [org.gnome.desktop.interface]
 clock-show-date=true
-color-scheme='prefer-dark'
 cursor-theme='breeze_cursors'
 document-font-name='Noto Sans 9'
 font-antialiasing='rgba'
 font-hinting='slight'
 font-name='Noto Sans 9'
-gtk-theme='adw-gtk3-dark'
+gtk-theme='adw-gtk3'
 icon-theme='Papirus'
 monospace-font-name='Hack 10'

--- a/schemas/org.gnome.desktop.wm.preferences.gschema.override
+++ b/schemas/org.gnome.desktop.wm.preferences.gschema.override
@@ -1,4 +1,4 @@
 [org.gnome.desktop.wm.preferences]
 button-layout='appmenu:minimize,maximize,close'
-theme='Adwaita-dark'
+theme='Adwaita'
 titlebar-font='Noto Sans Regular 11'


### PR DESCRIPTION
Many Qt app's theming really struggle with the dark theme, especially kirigami based apps.